### PR TITLE
Add analyzers and fix errors

### DIFF
--- a/src/Dogfood/Dogfood.csproj
+++ b/src/Dogfood/Dogfood.csproj
@@ -229,8 +229,21 @@
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\Microsoft.VisualStudio.SDK.Analyzers.15.8.36\analyzers\cs\Microsoft.VisualStudio.SDK.Analyzers.dll" />
+    <Analyzer Include="..\..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.8.168\analyzers\cs\Microsoft.VisualStudio.Threading.Analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="..\..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.8.168\build\Microsoft.VisualStudio.Threading.Analyzers.targets" Condition="Exists('..\..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.8.168\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.8.168\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.8.168\build\Microsoft.VisualStudio.Threading.Analyzers.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.VisualStudio.SDK.Analyzers.15.8.36\build\Microsoft.VisualStudio.SDK.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.VisualStudio.SDK.Analyzers.15.8.36\build\Microsoft.VisualStudio.SDK.Analyzers.targets'))" />
+  </Target>
+  <Import Project="..\..\packages\Microsoft.VisualStudio.SDK.Analyzers.15.8.36\build\Microsoft.VisualStudio.SDK.Analyzers.targets" Condition="Exists('..\..\packages\Microsoft.VisualStudio.SDK.Analyzers.15.8.36\build\Microsoft.VisualStudio.SDK.Analyzers.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/Dogfood/DogfoodPackage.cs
+++ b/src/Dogfood/DogfoodPackage.cs
@@ -20,10 +20,12 @@ namespace InstallExperiment
 
         protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {
-            var componentModel = (IComponentModel)await GetServiceAsync(typeof(SComponentModel));
-            foreach (var initializable in componentModel.GetExtensions<IAsyncInitializable>())
+            if (await GetServiceAsync(typeof(SComponentModel)) is IComponentModel componentModel)
             {
-                await initializable.InitializeAsync(this);
+                foreach (var initializable in componentModel.GetExtensions<IAsyncInitializable>())
+                {
+                    await initializable.InitializeAsync(this);
+                }
             }
         }
     }

--- a/src/Dogfood/DogfoodPackage.cs
+++ b/src/Dogfood/DogfoodPackage.cs
@@ -9,7 +9,7 @@ using Dogfood.Exports;
 
 namespace InstallExperiment
 {
-    [PackageRegistration(UseManagedResourcesOnly = true)]
+    [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
     [InstalledProductRegistration("#110", "#112", "1.0", IconResourceID = 400)] // Info on this package for Help/About
     [Guid(PackageGuidString)]
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1650:ElementDocumentationMustBeSpelledCorrectly", Justification = "pkgdef, VS and vsixmanifest are valid VS terms")]
@@ -21,7 +21,7 @@ namespace InstallExperiment
         protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {
             var componentModel = (IComponentModel)await GetServiceAsync(typeof(SComponentModel));
-            foreach(var initializable in componentModel.GetExtensions<IAsyncInitializable>())
+            foreach (var initializable in componentModel.GetExtensions<IAsyncInitializable>())
             {
                 await initializable.InitializeAsync(this);
             }

--- a/src/Dogfood/packages.config
+++ b/src/Dogfood/packages.config
@@ -5,6 +5,7 @@
   <package id="Microsoft.VisualStudio.Imaging" version="14.3.25407" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" version="14.3.25407" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.OLE.Interop" version="7.10.6070" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.SDK.Analyzers" version="15.8.36" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Shell.14.0" version="14.3.25407" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Shell.Immutable.10.0" version="10.0.30319" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Shell.Immutable.11.0" version="11.0.50727" targetFramework="net461" />
@@ -20,6 +21,7 @@
   <package id="Microsoft.VisualStudio.TextManager.Interop" version="7.10.6070" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.TextManager.Interop.8.0" version="8.0.50727" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Threading" version="14.1.131" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Threading.Analyzers" version="15.8.168" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Utilities" version="14.3.25407" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Validation" version="15.3.15" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
The following error was preventing publishing to the Marketplace:
```
VSSDK: error VsixPub0029 : An error occurred while communicating with the marketplace:
VSIXValidatorWarning06 - The async package (InstallExperiment.DogfoodPackage) class with a
PackageRegistration attribute should always be marked for AllowsBackgroundLoading to true.
Read more about background loading here: https://aka.ms/asyncpackage.
```

This PR will hopefully fix it!