### PR TITLE
Add support for Visual Studio 2019 Preview

### DIFF
--- a/src/Dogfood.Services/DogfoodService.cs
+++ b/src/Dogfood.Services/DogfoodService.cs
@@ -45,6 +45,8 @@ namespace Dogfood.Services
                     return CreateDogfoodService(() => new DogfoodService14(asyncServiceProvider, projectUtilities));
                 case "15.0":
                     return CreateDogfoodService(() => new DogfoodService15(asyncServiceProvider, projectUtilities));
+                case "16.0":
+                    return CreateDogfoodService(() => new DogfoodService15(asyncServiceProvider, projectUtilities));
                 default:
                     return null;
             }

--- a/src/Dogfood/source.extension.vsixmanifest
+++ b/src/Dogfood/source.extension.vsixmanifest
@@ -6,14 +6,14 @@
     <Description xml:space="preserve">Install local VSIX into current instance of Visual Studio</Description>
   </Metadata>
   <Installation AllUsers="true">
-    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Community" />
+    <InstallationTarget Version="[14.0,17.0)" Id="Microsoft.VisualStudio.Community" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-    <Dependency Id="Microsoft.VisualStudio.MPF.14.0" DisplayName="Visual Studio MPF 14.0" d:Source="Installed" Version="[14.0,15.0)" />
+    <Dependency Id="Microsoft.VisualStudio.MPF.14.0" DisplayName="Visual Studio MPF 14.0" d:Source="Installed" Version="[14.0,)" />
   </Dependencies>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[14.0,16.0)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
   </Prerequisites>
   <Assets>
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />


### PR DESCRIPTION
Update `source.extension.vsixmanifest` and `DogfoodService` factory.

- How to upgrade extensions to support Visual Studio 2019
https://madskristensen.net/blog/how-to-upgrade-extensions-to-support-visual-studio-2019/