### PR TITLE
Attempt to stop externally contributed PR builds from failing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,12 @@ variables:
   buildConfiguration: 'Release'
 
 steps:
+- powershell: |
+    # Set the cloud build number and variables
+    # https://github.com/AArnott/Nerdbank.GitVersioning   
+    dotnet tool install --tool-path . nbgv
+    .\nbgv cloud --all-vars
+  displayName: 'Set the cloud build number and variables'
 - task: NuGetToolInstaller@0
 
 - task: NuGetCommand@2

--- a/version.json
+++ b/version.json
@@ -3,10 +3,5 @@
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$"
-  ],
-  "cloudBuild": {
-    "buildNumber": {
-      "enabled": true
-    }
-  }
+  ]
 }


### PR DESCRIPTION
Set the cloud build variables a part of `azure-pipelines.yml` rather that as part of the solution build (a setting in `version.json`). 🤞 this will fix it.