### PR TITLE
Fix for VS 2019 SDK targeting .NET 4.7.2

### DIFF
--- a/src/Dogfood.Services.16.0/Dogfood.Services.16.0.csproj
+++ b/src/Dogfood.Services.16.0/Dogfood.Services.16.0.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dogfood.Services</RootNamespace>
     <AssemblyName>Dogfood.Services.16.0</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Dogfood.Services/Dogfood.Services.csproj
+++ b/src/Dogfood.Services/Dogfood.Services.csproj
@@ -63,21 +63,6 @@
       <Project>{36045d9c-c273-45ab-bdab-965b91914dcf}</Project>
       <Name>Dogfood.Exports</Name>
     </ProjectReference>
-    <ProjectReference Include="..\Dogfood.Services.14.0\Dogfood.Services.14.0.csproj">
-      <Project>{136eb190-87c5-454d-a866-c65fd6c5f8bb}</Project>
-      <Name>Dogfood.Services.14.0</Name>
-      <Aliases>global</Aliases>
-    </ProjectReference>
-    <ProjectReference Include="..\Dogfood.Services.15.0\Dogfood.Services.15.0.csproj">
-      <Project>{efc62dca-be25-4699-ba7a-445e0b34d3fa}</Project>
-      <Name>Dogfood.Services.15.0</Name>
-      <Aliases>global</Aliases>
-    </ProjectReference>
-    <ProjectReference Include="..\Dogfood.Services.16.0\Dogfood.Services.16.0.csproj">
-      <Project>{70337588-3b2b-49f6-a0df-e1c27cd608b3}</Project>
-      <Name>Dogfood.Services.16.0</Name>
-      <Aliases>global</Aliases>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="Key.snk" />

--- a/src/Dogfood.Services/Dogfood.Services.csproj
+++ b/src/Dogfood.Services/Dogfood.Services.csproj
@@ -66,17 +66,17 @@
     <ProjectReference Include="..\Dogfood.Services.14.0\Dogfood.Services.14.0.csproj">
       <Project>{136eb190-87c5-454d-a866-c65fd6c5f8bb}</Project>
       <Name>Dogfood.Services.14.0</Name>
-      <Aliases>DS14</Aliases>
+      <Aliases>global</Aliases>
     </ProjectReference>
     <ProjectReference Include="..\Dogfood.Services.15.0\Dogfood.Services.15.0.csproj">
       <Project>{efc62dca-be25-4699-ba7a-445e0b34d3fa}</Project>
       <Name>Dogfood.Services.15.0</Name>
-      <Aliases>DS15</Aliases>
+      <Aliases>global</Aliases>
     </ProjectReference>
     <ProjectReference Include="..\Dogfood.Services.16.0\Dogfood.Services.16.0.csproj">
       <Project>{70337588-3b2b-49f6-a0df-e1c27cd608b3}</Project>
       <Name>Dogfood.Services.16.0</Name>
-      <Aliases>DS16</Aliases>
+      <Aliases>global</Aliases>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Dogfood.Services/DogfoodService.cs
+++ b/src/Dogfood.Services/DogfoodService.cs
@@ -1,16 +1,10 @@
-﻿extern alias DS14;
-extern alias DS15;
-extern alias DS16;
-using System;
+﻿using System;
 using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
 using System.ComponentModel.Composition;
 using Dogfood.Exports;
 using EnvDTE;
-using DogfoodService14 = DS14::Dogfood.Services.DogfoodService;
-using DogfoodService15 = DS15::Dogfood.Services.DogfoodService;
-using DogfoodService16 = DS16::Dogfood.Services.DogfoodService;
 
 namespace Dogfood.Services
 {
@@ -38,25 +32,23 @@ namespace Dogfood.Services
         public Task<bool> Reinstall(string vsixFile, IProgress<string> progress) =>
             dogfoodService.Value.Reinstall(vsixFile, progress);
 
-        static IDogfoodService CreateDogfoodService(DTE dte, IServiceProvider serviceProvider,
-            IProjectUtilities projectUtilities)
+        IDogfoodService CreateDogfoodService(DTE dte, IServiceProvider serviceProvider, IProjectUtilities projectUtilities)
         {
             switch (dte.Version)
             {
                 case "14.0":
-                    return CreateDogfoodService(() => new DogfoodService14(serviceProvider, projectUtilities));
                 case "15.0":
-                    return CreateDogfoodService(() => new DogfoodService15(serviceProvider, projectUtilities));
+                    return CreateDogfoodService(dte.Version, serviceProvider, projectUtilities);
                 case "16.0":
                     try
                     {
                         Assembly.Load("Microsoft.VisualStudio.ExtensionManager, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
-                        return CreateDogfoodService(() => new DogfoodService16(serviceProvider, projectUtilities));
+                        return CreateDogfoodService(dte.Version, serviceProvider, projectUtilities);
                     }
                     catch (FileNotFoundException)
                     {
                         // If we can't load ExtensionManager 16.0, fall back to using the 15.0 version
-                        return CreateDogfoodService(() => new DogfoodService15(serviceProvider, projectUtilities));
+                        return CreateDogfoodService("15.0", serviceProvider, projectUtilities);
                     }
 
                 default:
@@ -64,6 +56,19 @@ namespace Dogfood.Services
             }
         }
 
-        static IDogfoodService CreateDogfoodService(Func<IDogfoodService> factory) => factory();
+        IDogfoodService CreateDogfoodService(string version, IServiceProvider serviceProvider, IProjectUtilities projectUtilities)
+        {
+            var executingType = GetType();
+            var fullName = executingType.FullName;
+            var assemblyName = executingType.Assembly.GetName();
+            assemblyName.Name = $"{assemblyName.Name}.{version}";
+            var assemblyQualifiedName = $"{fullName}, {assemblyName}";
+            if (Type.GetType(assemblyQualifiedName, false) is Type targetType)
+            {
+                return (IDogfoodService)Activator.CreateInstance(targetType, serviceProvider, projectUtilities);
+            }
+
+            return null;
+        }
     }
 }

--- a/src/Dogfood/Dogfood.csproj
+++ b/src/Dogfood/Dogfood.csproj
@@ -6,6 +6,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <UseCodebase>true</UseCodebase>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
@@ -24,7 +25,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dogfood</RootNamespace>
     <AssemblyName>Dogfood</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>true</IncludeDebugSymbolsInVSIXContainer>


### PR DESCRIPTION
We can no longer reference the 16.0 assembly because it targets .NET 4.7.2.

- Use reflection to create the version specific `DogfoodService` implementation