### PR TITLE
Be specific about which AppID AllUsers=true extensions are uninstalled from

### DIFF
--- a/src/Dogfood.Services.14.0/DogfoodService.cs
+++ b/src/Dogfood.Services.14.0/DogfoodService.cs
@@ -91,7 +91,7 @@ namespace Dogfood.Services
                 return false;
             }
 
-            var startInfo = new ProcessStartInfo(application, $"/uninstall:{identifier}");
+            var startInfo = new ProcessStartInfo(application, $"/uninstall:{identifier} /appIdInstallPath:\"{dte.FileName}\" /appIdName:VS /skuName:{dte.Edition} /skuVersion:{dte.Version}");
             Process.Start(startInfo);
             return true;
         }


### PR DESCRIPTION
Previously `AllUsers=true` extensions would be uninstalled from all VS applications. This could take a long time and was overkill.

## What this PR does

- When uninstalling using `VSIXInstaller`, specify the `appIdInstallPath`, `appIdName`, `skuName` and `skuVersion` to uninstall from